### PR TITLE
Search dups

### DIFF
--- a/src/app/search-results/search-results.component.html
+++ b/src/app/search-results/search-results.component.html
@@ -4,7 +4,7 @@
 <mat-grid-list class="browse-grid-list" cols="5" gutterSize="6px">
   <div class="tile-container" *ngFor="let result of results">
       <mat-grid-tile>
-        <a routerLink="/library/releases/{{result.release.id}}">
+        <a routerLink="/browse/releases/{{result.release.id}}">
           <img class="shelves-app-artist-preview"
             width="100%"
             alt="{{result.release.title}}"

--- a/src/app/search-results/search-results.component.ts
+++ b/src/app/search-results/search-results.component.ts
@@ -37,7 +37,14 @@ export class SearchResultsComponent implements OnInit, OnDestroy {
     const query = this._route.snapshot.paramMap.get('query');
     this.searchService.getSearchResults(query, this.maxResults)
     .subscribe((results) => {
-      this.results = results;
+      const releaseGroupIDs = new Map();
+      this.results = [];
+      results.forEach((result) => {
+        if (!releaseGroupIDs.has(result.release.KEXPReleaseGroupMBID)) {
+          this.results.push(result);
+          releaseGroupIDs.set(result.release.KEXPReleaseGroupMBID, true);
+        }
+      });
       this.noResults = (this.results.length === 0);
     });
   }


### PR DESCRIPTION
- Shows a single release from a release group in search results
- Fixed routing from search result to a release detail
- Temporary fix--we should add the ability to toggle through multiple releases within a group in v2.