### PR TITLE
Shelf preview images

### DIFF
--- a/src/_app-theme.scss
+++ b/src/_app-theme.scss
@@ -7,6 +7,7 @@
 @import './app/auth/signup/signup-theme';
 @import './app/search-results/search-results-theme';
 @import './app/release/release-detail/release-detail-theme';
+@import './app/shelves/shelf-preview/shelf-preview-theme';
 
 @mixin shelves-app-theme($theme) {
     $primary: map-get($theme, primary);
@@ -32,4 +33,5 @@
     @include signup-theme($theme);
     @include search-results-theme($theme);
     @include release-detail-theme($theme);
+    @include shelf-preview-theme($theme);
 }

--- a/src/app/release/release-notes/release-notes.component.html
+++ b/src/app/release/release-notes/release-notes.component.html
@@ -1,5 +1,5 @@
 <div class="row dialog-header">
-  <img class="album-image" src="//coverartarchive.org/release-group/{{release.KEXPReleaseGroupMBID}}/front-500.jpg">
+  <img class="notes-album-image" src="//coverartarchive.org/release-group/{{release.KEXPReleaseGroupMBID}}/front-500.jpg">
   <div class="column">
     <h1 mat-dialog-title class="release-title">{{release.title}}</h1>
     <h5 class="release-artist">{{release.KEXPReleaseArtistCredit}}</h5>

--- a/src/app/release/release-notes/release-notes.component.scss
+++ b/src/app/release/release-notes/release-notes.component.scss
@@ -8,7 +8,7 @@ h5 {
     margin: 0px;
 }
 
-.album-image {
+.notes-album-image {
     width: 6.5rem;
     max-width: 100%;
 }
@@ -75,6 +75,7 @@ h5 {
 .dialog-header {
     height: 10%;
     margin: 10px;
+    display: -webkit-box;
 }
 
 .note-container {

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -3,14 +3,23 @@ import { CommonModule } from '@angular/common';
 
 import { MaterialModule } from './material/material.module';
 import { MatInputModule } from '@angular/material';
+import { ShelfPreviewComponent } from '../shelves/shelf-preview/shelf-preview.component';
+import { RouterModule } from '@angular/router';
+import { BrowserModule } from '@angular/platform-browser';
 
 @NgModule({
     declarations: [
+        ShelfPreviewComponent // declared here since needs to be used at two lower levels (AppModule and ShelvesModule)
+    ],
+    imports: [
+        RouterModule, // required here because of ShelfPreviewComponent
+        BrowserModule
     ],
     exports: [
         CommonModule,
         MaterialModule,
-        MatInputModule
+        MatInputModule,
+        ShelfPreviewComponent
         // other shared components/directives etc
     ]
 })

--- a/src/app/shelf-add/shelf-add.component.html
+++ b/src/app/shelf-add/shelf-add.component.html
@@ -1,5 +1,5 @@
 <div class="dialog-header">
-  <img class="album-image" src="//coverartarchive.org/release-group/{{release.KEXPReleaseGroupMBID}}/front-500.jpg">
+  <img class="shelf-add-album-image" src="//coverartarchive.org/release-group/{{release.KEXPReleaseGroupMBID}}/front-500.jpg">
   <div class="column">
     <h1 mat-dialog-title class="release-title">{{release.title}}</h1>
     <h5 class="release-artist">{{release.KEXPReleaseArtistCredit}}</h5>

--- a/src/app/shelf-add/shelf-add.component.html
+++ b/src/app/shelf-add/shelf-add.component.html
@@ -37,8 +37,7 @@
   </div>
   <mat-divider></mat-divider>
   <div class="shelf-preview">
-    <h3>{{currShelfName}}</h3>
-    <img *ngFor="let mbid of selectedShelfReleaseIds" class="album-image shelf-preview-img" src="//coverartarchive.org/release/{{mbid}}/front-500.jpg"> 
+      <app-shelf-preview *ngIf="currShelf" [shelf]="currShelf" [clickable]="false"></app-shelf-preview>
   </div>
   <div>
     <button class="mat-raised-button add-btn" (click)="addToShelf(pickShelf)">Add!</button>

--- a/src/app/shelf-add/shelf-add.component.scss
+++ b/src/app/shelf-add/shelf-add.component.scss
@@ -13,8 +13,8 @@
 }
 
 .album-image {
-    width: 6.5rem;
-    max-width: 100%;
+    // width: 6.5rem;
+    // max-width: 100%;
 }
 
 h5 {

--- a/src/app/shelf-add/shelf-add.component.scss
+++ b/src/app/shelf-add/shelf-add.component.scss
@@ -12,9 +12,9 @@
     margin: 10px;
 }
 
-.album-image {
-    // width: 6.5rem;
-    // max-width: 100%;
+.shelf-add-album-image {
+    width: 6.5rem;
+    max-width: 100%;
 }
 
 h5 {

--- a/src/app/shelf-add/shelf-add.component.ts
+++ b/src/app/shelf-add/shelf-add.component.ts
@@ -15,8 +15,6 @@ import { Shelf, NewShelf } from '../models/shelf';
 export class ShelfAddComponent implements OnInit {
   private release: Release;
   private userShelves: Shelf[];
-  private selectedShelfReleaseIds: string[] = [];
-  private currShelfName: string;
   private currShelf: Shelf;
 
   constructor(
@@ -49,9 +47,6 @@ export class ShelfAddComponent implements OnInit {
   }
 
   updateShelfPreview(form: NgForm) {
-    console.log(form.value.shelfPicker);
-    // this.selectedShelfReleaseIds = form.value.shelfPicker.releaseIDs;
-    // this.currShelfName = form.value.shelfPicker.name;
     this.currShelf = form.value.shelfPicker;
   }
 
@@ -78,7 +73,9 @@ export class ShelfAddComponent implements OnInit {
       });
   }
 
-  getCurrShelf() {}
+  getCurrShelf() {
+    return this.currShelf;
+  }
 
   addToShelf(form: NgForm) {
     const shelf = form.value.shelfPicker;

--- a/src/app/shelf-add/shelf-add.component.ts
+++ b/src/app/shelf-add/shelf-add.component.ts
@@ -17,7 +17,7 @@ export class ShelfAddComponent implements OnInit {
   private userShelves: Shelf[];
   private selectedShelfReleaseIds: string[] = [];
   private currShelfName: string;
-
+  private currShelf: Shelf;
 
   constructor(
     @Inject(MAT_DIALOG_DATA) release,
@@ -50,8 +50,9 @@ export class ShelfAddComponent implements OnInit {
 
   updateShelfPreview(form: NgForm) {
     console.log(form.value.shelfPicker);
-    this.selectedShelfReleaseIds = form.value.shelfPicker.releaseIDs;
-    this.currShelfName = form.value.shelfPicker.name;
+    // this.selectedShelfReleaseIds = form.value.shelfPicker.releaseIDs;
+    // this.currShelfName = form.value.shelfPicker.name;
+    this.currShelf = form.value.shelfPicker;
   }
 
 

--- a/src/app/shelves/shelf-preview/_shelf-preview-theme.scss
+++ b/src/app/shelves/shelf-preview/_shelf-preview-theme.scss
@@ -1,0 +1,22 @@
+@import '../../../../node_modules/@angular/material/theming';
+
+@mixin shelf-preview-theme($theme) {
+    $primary: map-get($theme, primary);
+    $accent: map-get($theme, accent);
+    $background: map-get($theme, background);
+    $foreground: map-get($theme, foreground);
+
+
+    .mat-grid-tile .mat-grid-tile-footer.tile-footer {
+        background: rgba(0, 0, 0, .90);
+    }
+
+    .shelf-preview-img {
+
+        &:after {
+            background: linear-gradient(mat-color($primary), mat-color($primary, darker));
+            // background: mat-color($background, card);
+            color: mat-color($foreground, text);
+        }
+    }
+}

--- a/src/app/shelves/shelf-preview/shelf-preview.component.html
+++ b/src/app/shelves/shelf-preview/shelf-preview.component.html
@@ -1,10 +1,12 @@
 <div>
   <h3>{{shelf.name}}</h3>
-  <div *ngFor="let mbid of shelf.releaseIDs">
-    <a *ngIf="clickable" routerLink="/browse/releases/{{mbid}}">
-      <img class="shelf-preview-img" src="//coverartarchive.org/release/{{mbid}}/front-500.jpg">
-    </a>
-    <!-- <img *ngIf="!clickable" class="shelf-preview-img" src="//coverartarchive.org/release/{{mbid}}/front-500.jpg"> -->
-    <img *ngIf="!clickable" class="shelf-preview-img" [src]="getArt(mbid) || getBackupArt(mbid)">
+  <div class="container">
+    <div *ngFor="let mbid of shelf.releaseIDs">
+      <a *ngIf="clickable" routerLink="/browse/releases/{{mbid}}">
+        <img class="shelf-preview-img" src="//coverartarchive.org/release/{{mbid}}/front-500.jpg">
+      </a>
+      <!-- <img *ngIf="!clickable" class="shelf-preview-img" src="//coverartarchive.org/release/{{mbid}}/front-500.jpg"> -->
+      <img *ngIf="!clickable" class="shelf-preview-img" [src]="getArt(mbid) || getBackupArt(mbid)">
+    </div>
   </div>
 </div>

--- a/src/app/shelves/shelf-preview/shelf-preview.component.html
+++ b/src/app/shelves/shelf-preview/shelf-preview.component.html
@@ -4,6 +4,7 @@
     <a *ngIf="clickable" routerLink="/browse/releases/{{mbid}}">
       <img class="shelf-preview-img" src="//coverartarchive.org/release/{{mbid}}/front-500.jpg">
     </a>
-    <img *ngIf="!clickable" class="shelf-preview-img" src="//coverartarchive.org/release/{{mbid}}/front-500.jpg">
+    <!-- <img *ngIf="!clickable" class="shelf-preview-img" src="//coverartarchive.org/release/{{mbid}}/front-500.jpg"> -->
+    <img *ngIf="!clickable" class="shelf-preview-img" [src]="getArt(mbid)">
   </div>
 </div>

--- a/src/app/shelves/shelf-preview/shelf-preview.component.html
+++ b/src/app/shelves/shelf-preview/shelf-preview.component.html
@@ -3,7 +3,7 @@
   <div class="container">
     <div *ngFor="let mbid of shelf.releaseIDs">
       <a *ngIf="clickable" routerLink="/browse/releases/{{mbid}}">
-        <img class="shelf-preview-img" src="//coverartarchive.org/release/{{mbid}}/front-500.jpg">
+        <img class="shelf-preview-img" src="{{imgUrls.get(mbid)}}" (error)="img.src=getBackupArt(mbid)">
       </a>
       <!-- <img *ngIf="!clickable" class="shelf-preview-img" src="//coverartarchive.org/release/{{mbid}}/front-500.jpg"> -->
       <img *ngIf="!clickable" class="shelf-preview-img" [src]="getArt(mbid) || getBackupArt(mbid)">

--- a/src/app/shelves/shelf-preview/shelf-preview.component.html
+++ b/src/app/shelves/shelf-preview/shelf-preview.component.html
@@ -1,8 +1,9 @@
 <div>
   <h3>{{shelf.name}}</h3>
   <div *ngFor="let mbid of shelf.releaseIDs">
-    <a routerLink="/browse/releases/{{mbid}}">
+    <a *ngIf="clickable" routerLink="/browse/releases/{{mbid}}">
       <img class="shelf-preview-img" src="//coverartarchive.org/release/{{mbid}}/front-500.jpg">
     </a>
+    <img *ngIf="!clickable" class="shelf-preview-img" src="//coverartarchive.org/release/{{mbid}}/front-500.jpg">
   </div>
 </div>

--- a/src/app/shelves/shelf-preview/shelf-preview.component.html
+++ b/src/app/shelves/shelf-preview/shelf-preview.component.html
@@ -5,6 +5,6 @@
       <img class="shelf-preview-img" src="//coverartarchive.org/release/{{mbid}}/front-500.jpg">
     </a>
     <!-- <img *ngIf="!clickable" class="shelf-preview-img" src="//coverartarchive.org/release/{{mbid}}/front-500.jpg"> -->
-    <img *ngIf="!clickable" class="shelf-preview-img" [src]="getArt(mbid)">
+    <img *ngIf="!clickable" class="shelf-preview-img" [src]="getArt(mbid) || getBackupArt(mbid)">
   </div>
 </div>

--- a/src/app/shelves/shelf-preview/shelf-preview.component.html
+++ b/src/app/shelves/shelf-preview/shelf-preview.component.html
@@ -3,10 +3,9 @@
   <div class="container">
     <div *ngFor="let mbid of shelf.releaseIDs">
       <a *ngIf="clickable" routerLink="/browse/releases/{{mbid}}">
-        <img class="shelf-preview-img" src="{{imgUrls.get(mbid)}}" (error)="img.src=getBackupArt(mbid)">
+        <img class="shelf-preview-img" src="{{imgUrls.get(mbid)}}" (error)="getBackupArt(mbid)">
       </a>
-      <!-- <img *ngIf="!clickable" class="shelf-preview-img" src="//coverartarchive.org/release/{{mbid}}/front-500.jpg"> -->
-      <img *ngIf="!clickable" class="shelf-preview-img" [src]="getArt(mbid) || getBackupArt(mbid)">
+      <img *ngIf="!clickable" class="shelf-preview-img" src="{{imgUrls.get(mbid)}}" (error)="img.src = getBackupArt(mbid)">
     </div>
   </div>
 </div>

--- a/src/app/shelves/shelf-preview/shelf-preview.component.scss
+++ b/src/app/shelves/shelf-preview/shelf-preview.component.scss
@@ -1,5 +1,5 @@
 .shelf-preview-img {
-    width: 6.5rem;
+    width: 8rem;
     max-width: 100%;
     margin: 5px;
 }
@@ -10,4 +10,20 @@
 
 h3 {
     color: white;
+}
+
+img.shelf-preview-img:after {
+    content: attr(alt);
+    font-size: 16px;
+    
+    display: block;
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+    justify-content: center;
+    z-index: 0;
+    top: 0;
+    left: 0;
+    width: 6.5rem;
 }

--- a/src/app/shelves/shelf-preview/shelf-preview.component.scss
+++ b/src/app/shelves/shelf-preview/shelf-preview.component.scss
@@ -17,13 +17,13 @@ img.shelf-preview-img:after {
     font-size: 16px;
     
     display: block;
-    position: absolute;
-    display: flex;
+    position: relative;
     flex-direction: column;
     text-align: center;
     justify-content: center;
     z-index: 0;
     top: 0;
     left: 0;
-    width: 6.5rem;
+    width: 128px;
+    height: 128px;
 }

--- a/src/app/shelves/shelf-preview/shelf-preview.component.scss
+++ b/src/app/shelves/shelf-preview/shelf-preview.component.scss
@@ -3,3 +3,11 @@
     max-width: 100%;
     margin: 5px;
 }
+
+.container {
+    display: flex;
+}
+
+h3 {
+    color: white;
+}

--- a/src/app/shelves/shelf-preview/shelf-preview.component.ts
+++ b/src/app/shelves/shelf-preview/shelf-preview.component.ts
@@ -16,9 +16,6 @@ export class ShelfPreviewComponent implements OnInit {
   constructor(private libraryService: LibraryService) { }
 
   ngOnInit() {
-    this.shelf.ReleaseIds.forEach((mbid) => {
-      this.imgUrls.set(mbid, `//coverartarchive.org/release/${mbid}/front-500.jpg`);
-    });
   }
 
   getArt(mbid: string) {
@@ -29,10 +26,7 @@ export class ShelfPreviewComponent implements OnInit {
     console.log(mbid);
     this.libraryService.getReleaseById(mbid)
       .subscribe((release) => {
-        console.log('got backup art!');
-        console.log(release);
         this.imgUrls.set(release.id, `//coverartarchive.org/release-group/${release.KEXPReleaseGroupMBID}/front-500.jpg`);
-        return `//coverartarchive.org/release-group/${release.KEXPReleaseGroupMBID}/front-500.jpg`;
       });
   }
 }

--- a/src/app/shelves/shelf-preview/shelf-preview.component.ts
+++ b/src/app/shelves/shelf-preview/shelf-preview.component.ts
@@ -11,10 +11,14 @@ import { LibraryService } from '../../library.service';
 export class ShelfPreviewComponent implements OnInit {
   @Input() shelf: Shelf;
   @Input() clickable: boolean;
+  private imgUrls = new Map();
 
   constructor(private libraryService: LibraryService) { }
 
   ngOnInit() {
+    this.shelf.ReleaseIds.forEach((mbid) => {
+      this.imgUrls.set(mbid, `//coverartarchive.org/release/${mbid}/front-500.jpg`);
+    });
   }
 
   getArt(mbid: string) {
@@ -25,6 +29,9 @@ export class ShelfPreviewComponent implements OnInit {
     console.log(mbid);
     this.libraryService.getReleaseById(mbid)
       .subscribe((release) => {
+        console.log('got backup art!');
+        console.log(release);
+        this.imgUrls.set(release.id, `//coverartarchive.org/release-group/${release.KEXPReleaseGroupMBID}/front-500.jpg`);
         return `//coverartarchive.org/release-group/${release.KEXPReleaseGroupMBID}/front-500.jpg`;
       });
   }

--- a/src/app/shelves/shelf-preview/shelf-preview.component.ts
+++ b/src/app/shelves/shelf-preview/shelf-preview.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { Release } from '../../models/release';
 import { Shelf } from '../../models/shelf';
+import { LibraryService } from '../../library.service';
 
 @Component({
   selector: 'app-shelf-preview',
@@ -11,11 +12,20 @@ export class ShelfPreviewComponent implements OnInit {
   @Input() shelf: Shelf;
   @Input() clickable: boolean;
 
-  constructor() { }
+  constructor(private libraryService: LibraryService) { }
 
   ngOnInit() {
   }
 
+  getArt(mbid: string) {
+    return `//coverartarchive.org/release/${mbid}/front-500.jpg`;
+  }
 
-
+  getBackupArt(mbid: string) {
+    console.log(mbid);
+    this.libraryService.getReleaseById(mbid)
+      .subscribe((release) => {
+        return `//coverartarchive.org/release-group/${release.KEXPReleaseGroupMBID}/front-500.jpg`;
+      });
+  }
 }

--- a/src/app/shelves/shelf-preview/shelf-preview.component.ts
+++ b/src/app/shelves/shelf-preview/shelf-preview.component.ts
@@ -9,6 +9,7 @@ import { Shelf } from '../../models/shelf';
 })
 export class ShelfPreviewComponent implements OnInit {
   @Input() shelf: Shelf;
+  @Input() clickable: boolean;
 
   constructor() { }
 

--- a/src/app/shelves/shelves-list/shelves-list.component.html
+++ b/src/app/shelves/shelves-list/shelves-list.component.html
@@ -1,7 +1,7 @@
 <mat-tab-group>
   <mat-tab label="Mine">
     <div *ngFor="let shelf of myShelves">
-      <app-shelf-preview *ngIf="shelf" [shelf]="shelf"></app-shelf-preview>
+      <app-shelf-preview *ngIf="shelf" [shelf]="shelf" [clickable]="true"></app-shelf-preview>
     </div>
     <div *ngIf="!isAuthenticated">
       <p>You have no shelves because you are not logged in</p>
@@ -12,7 +12,7 @@
   </mat-tab>
   <mat-tab label="All">
     <div *ngFor="let shelf of allShelves">
-      <app-shelf-preview *ngIf="shelf" [shelf]="shelf"></app-shelf-preview>
+      <app-shelf-preview *ngIf="shelf" [shelf]="shelf" [clickable]="true"></app-shelf-preview>
     </div>
     <div *ngIf="allShelves.length == 0">
       <p>There are no shelves!</p>
@@ -20,7 +20,7 @@
   </mat-tab>
   <mat-tab label="Featured">
     <div *ngFor="let shelf of featuredShelves">
-      <app-shelf-preview *ngIf="shelf" [shelf]="shelf"></app-shelf-preview>
+      <app-shelf-preview *ngIf="shelf" [shelf]="shelf" [clickable]="true"></app-shelf-preview>
     </div>
     <div *ngIf="featuredShelves.length == 0">
       <p>There are no featured shelves!</p>

--- a/src/app/shelves/shelves.module.ts
+++ b/src/app/shelves/shelves.module.ts
@@ -5,17 +5,19 @@ import { ShelfDetailComponent } from './shelf-detail/shelf-detail.component';
 import { ShelfItemComponent } from './shelf-item/shelf-item.component';
 import { ShelfPreviewComponent } from './shelf-preview/shelf-preview.component';
 import { RouterModule } from '@angular/router';
+import { BrowserModule } from '@angular/platform-browser';
 
 @NgModule({
   declarations: [
     ShelvesListComponent, // list of all shelves
-    ShelfPreviewComponent, // an item in the list of shelves
+    // ShelfPreviewComponent, // an item in the list of shelves
     ShelfDetailComponent, // a collection view of a shelf
     ShelfItemComponent // a single item in a shelf (a release)
   ],
   imports: [
     SharedModule,
-    RouterModule
+    RouterModule,
+    BrowserModule
   ]
 })
 export class ShelvesModule { }


### PR DESCRIPTION
Includes fallback with gradient and getting release group picture from cover art archive.  It actually ends up getting the release group picture for every release, even if there is a cover art archive release picture.  This has to do with how databinding and *ngFor work, as it will default to the (error) attribute if one of the children has an error. Or so it seems.  I'll take a look later but just need to get this somewhat functional.