### PR TITLE
Determine if user is authenticated if token present

### DIFF
--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -17,7 +17,7 @@ const fullHttpOptions = {
 
 @Injectable()
 export class AuthService {
-    public isAuthenticated: boolean;
+    public isAuthenticated: boolean = this.getToken() ? true : false;
 
     constructor(private http: HttpClient, private router: Router) { }
 


### PR DESCRIPTION
Fixes an issue where after a page reload certain portions of the application would recognize the user was authenticated, but the conditional portion (login/signup/logout) of the header wouldn't. 