### PR TITLE
Limit shelf preview to 6 releases

### DIFF
--- a/src/app/shelves/shelf-preview/shelf-preview.component.html
+++ b/src/app/shelves/shelf-preview/shelf-preview.component.html
@@ -1,7 +1,7 @@
 <div>
   <h3>{{shelf.name}}</h3>
   <div class="container">
-    <div *ngFor="let mbid of shelf.releaseIDs">
+    <div *ngFor="let mbid of shelf.releaseIDs | slice:0:6">
       <a *ngIf="clickable" routerLink="/browse/releases/{{mbid}}">
         <img class="shelf-preview-img" src="{{imgUrls.get(mbid)}}" (error)="getBackupArt(mbid)">
       </a>


### PR DESCRIPTION
Since the idea is to use shelf preview on the add-to-shelf dialog, limiting is added here.  We will move the standard shelves page away from shelf previews.