### PR TITLE
Make shelf preview items visible, add +x more if large shelf

### DIFF
--- a/src/app/shelves/shelf-preview/_shelf-preview-theme.scss
+++ b/src/app/shelves/shelf-preview/_shelf-preview-theme.scss
@@ -19,4 +19,11 @@
             color: mat-color($foreground, text);
         }
     }
+
+    .more-releases {
+        margin: 5px;
+        background: linear-gradient(mat-color($primary), mat-color($primary, darker));
+        // background: mat-color($background, card);
+        color: mat-color($foreground, text);
+    }
 }

--- a/src/app/shelves/shelf-preview/shelf-preview.component.html
+++ b/src/app/shelves/shelf-preview/shelf-preview.component.html
@@ -1,11 +1,18 @@
 <div>
   <h3>{{shelf.name}}</h3>
   <div class="container">
-    <div *ngFor="let mbid of shelf.releaseIDs | slice:0:6">
-      <a *ngIf="clickable" routerLink="/browse/releases/{{mbid}}">
-        <img class="shelf-preview-img" src="{{imgUrls.get(mbid)}}" (error)="getBackupArt(mbid)">
+    <div *ngFor="let release of shelf.releases | slice:0:5">
+      <a *ngIf="clickable" routerLink="/browse/releases/{{release.id}}">
+        <img class="shelf-preview-img" src="{{imgUrls.get(release.id)}}" (error)="getBackupArt(release.id)" alt="{{release.title}}"> 
       </a>
-      <img *ngIf="!clickable" class="shelf-preview-img" src="{{imgUrls.get(mbid)}}" (error)="getBackupArt(mbid)">
+      <img *ngIf="!clickable" class="shelf-preview-img" src="{{imgUrls.get(release.id)}}" (error)="getBackupArt(release.id)" alt="{{release.title}}">
+    </div>
+    <div *ngIf="shelf.releases.length > 5">
+        <div class="more-releases">
+            <div class="album-dialog-ctrl">
+              +{{shelf.releases.length - 5}} more
+            </div>
+        </div>
     </div>
   </div>
 </div>

--- a/src/app/shelves/shelf-preview/shelf-preview.component.scss
+++ b/src/app/shelves/shelf-preview/shelf-preview.component.scss
@@ -12,7 +12,7 @@ h3 {
     color: white;
 }
 
-img.shelf-preview-img:after {
+img.shelf-preview-img:after, .more-releases {
     content: attr(alt);
     font-size: 16px;
     
@@ -27,3 +27,4 @@ img.shelf-preview-img:after {
     width: 128px;
     height: 128px;
 }
+


### PR DESCRIPTION
Addresses the fact shelves now store entire releases--does NOT address styling concerns, particularly re: albums with missing artwork.